### PR TITLE
Add role guards and workflow logging

### DIFF
--- a/src/Core/LoggerTrait.php
+++ b/src/Core/LoggerTrait.php
@@ -1,0 +1,22 @@
+<?php
+namespace App\Core;
+
+use App\Models\HistoryLog;
+use PDO;
+
+trait LoggerTrait
+{
+    private function logAction(string $entityType, int $entityId, string $action, int $userId, array $snapshot): void
+    {
+        $database = new Database();
+        $db = $database->getConnection();
+        $log = new HistoryLog($db);
+        $log->entity_type = $entityType;
+        $log->entity_id = $entityId;
+        $log->action = $action;
+        $log->changed_by_user_id = $userId;
+        $log->timestamp = date('Y-m-d H:i:s');
+        $log->data_snapshot = $snapshot;
+        $log->create();
+    }
+}

--- a/src/Core/RoleGuard.php
+++ b/src/Core/RoleGuard.php
@@ -1,0 +1,27 @@
+<?php
+namespace App\Core;
+
+use App\Core\Database;
+use PDO;
+
+class RoleGuard
+{
+    private $db;
+
+    public function __construct()
+    {
+        $database = new Database();
+        $this->db = $database->getConnection();
+    }
+
+    public function checkRole(int $userId, array $allowedRoles): bool
+    {
+        $stmt = $this->db->prepare('SELECT role FROM users WHERE id = ? LIMIT 1');
+        $stmt->bindParam(1, $userId);
+        $stmt->execute();
+        if ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            return in_array($row['role'], $allowedRoles, true);
+        }
+        return false;
+    }
+}

--- a/src/Models/Wallet.php
+++ b/src/Models/Wallet.php
@@ -31,4 +31,24 @@ class Wallet {
         $stmt->execute();
         return $stmt;
     }
+
+    public function updateBalance(int $userId, float $amount): bool
+    {
+        $query = "UPDATE {$this->table_name} SET balance = balance + :amount WHERE user_id = :user_id";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(':amount', $amount);
+        $stmt->bindParam(':user_id', $userId);
+        return $stmt->execute();
+    }
+
+    public function addTransaction(int $userId, float $amount, string $type, string $createdAt): bool
+    {
+        $query = "INSERT INTO transactions (user_id, amount, type, created_at) VALUES (:user_id, :amount, :type, :created_at)";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(':user_id', $userId);
+        $stmt->bindParam(':amount', $amount);
+        $stmt->bindParam(':type', $type);
+        $stmt->bindParam(':created_at', $createdAt);
+        return $stmt->execute();
+    }
 }


### PR DESCRIPTION
## Summary
- enforce user roles with new `RoleGuard`
- add centralized history logging via `LoggerTrait`
- update wallet model with balance helpers
- secure payment creation and update wallet
- restrict order and item actions to proper roles

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68411b5ddc34832abbf62d3891471117