### PR TITLE
Add example MySQL seed data

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ php -S localhost:8000 index.php
 
 All requests are routed through `index.php`.
 
+## Example data
+
+The repository provides `example_data.sql` with the full schema and seed rows.
+It creates sample users (including **owner** and **assistant** roles stored in a `role` column),
+orders, wallets and related records. Import it into an empty MySQL database to start quickly:
+
+```bash
+mysql < example_data.sql
+```
+
 ## Endpoints
 
 ### Authentication

--- a/example_data.sql
+++ b/example_data.sql
@@ -1,0 +1,111 @@
+-- Example database schema and seed data for BazarTrack-API
+
+-- Users table
+CREATE TABLE users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    email VARCHAR(100) NOT NULL UNIQUE,
+    password VARCHAR(255) NOT NULL,
+    role VARCHAR(50) NOT NULL
+);
+
+-- Wallets table
+CREATE TABLE wallets (
+    user_id INT PRIMARY KEY,
+    balance DECIMAL(10,2) NOT NULL DEFAULT 0,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+-- Orders table
+CREATE TABLE orders (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    created_by INT NOT NULL,
+    assigned_to INT NULL,
+    status VARCHAR(50) NOT NULL,
+    created_at DATETIME NOT NULL,
+    completed_at DATETIME NULL,
+    FOREIGN KEY (created_by) REFERENCES users(id),
+    FOREIGN KEY (assigned_to) REFERENCES users(id)
+);
+
+-- Order items table
+CREATE TABLE order_items (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    order_id INT NOT NULL,
+    product_name VARCHAR(100) NOT NULL,
+    quantity INT NOT NULL,
+    unit VARCHAR(20) DEFAULT '',
+    estimated_cost DECIMAL(10,2) NULL,
+    actual_cost DECIMAL(10,2) NULL,
+    status VARCHAR(50) NOT NULL,
+    FOREIGN KEY (order_id) REFERENCES orders(id)
+);
+
+-- Transactions table
+CREATE TABLE transactions (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    amount DECIMAL(10,2) NOT NULL,
+    type VARCHAR(50) NOT NULL,
+    created_at DATETIME NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+-- Payments table
+CREATE TABLE payments (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    amount DECIMAL(10,2) NOT NULL,
+    type VARCHAR(50) NOT NULL,
+    created_at DATETIME NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+-- History logs table
+CREATE TABLE history_logs (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    entity_type VARCHAR(50) NOT NULL,
+    entity_id INT NOT NULL,
+    action VARCHAR(100) NOT NULL,
+    changed_by_user_id INT NOT NULL,
+    timestamp DATETIME NOT NULL,
+    data_snapshot JSON NULL
+);
+
+-- Sample users
+INSERT INTO users (id, name, email, password, role) VALUES
+    (1, 'Alice', 'alice@example.com', 'password1', 'owner'),
+    (2, 'Bob', 'bob@example.com', 'password2', 'assistant');
+
+-- Sample wallets
+INSERT INTO wallets (user_id, balance) VALUES
+    (1, 100.00),
+    (2, 50.00);
+
+-- Sample orders
+INSERT INTO orders (id, created_by, assigned_to, status, created_at, completed_at) VALUES
+    (1, 1, 2, 'pending', '2025-01-01 10:00:00', NULL),
+    (2, 1, NULL, 'completed', '2025-01-02 11:00:00', '2025-01-03 12:00:00');
+
+-- Sample order items
+INSERT INTO order_items (order_id, product_name, quantity, unit, estimated_cost, actual_cost, status) VALUES
+    (1, 'Apples', 10, 'kg', 20.00, 18.50, 'ordered'),
+    (1, 'Oranges', 5, 'kg', 12.00, 11.50, 'ordered'),
+    (2, 'Bananas', 3, 'kg', 6.00, 5.50, 'delivered');
+
+-- Sample transactions
+INSERT INTO transactions (user_id, amount, type, created_at) VALUES
+    (1, 25.00, 'credit', '2025-01-05 09:00:00'),
+    (1, 10.00, 'debit', '2025-01-06 09:30:00'),
+    (2, 50.00, 'credit', '2025-01-05 10:00:00');
+
+-- Sample payments
+INSERT INTO payments (user_id, amount, type, created_at) VALUES
+    (1, 25.00, 'wallet', '2025-01-05 09:00:00'),
+    (2, 50.00, 'wallet', '2025-01-05 10:00:00');
+
+-- Sample history logs
+INSERT INTO history_logs (entity_type, entity_id, action, changed_by_user_id, timestamp, data_snapshot) VALUES
+    ('order', 1, 'created', 1, '2025-01-01 10:00:00', '{"status":"pending"}'),
+    ('order', 2, 'completed', 1, '2025-01-03 12:00:00', '{"status":"completed"}');
+


### PR DESCRIPTION
## Summary
- add `example_data.sql` containing database schema and sample rows
- embed user role in the users table rather than using a separate roles table

## Testing
- `php -l index.php` *(fails: `php` not installed)*


------
https://chatgpt.com/codex/tasks/task_b_68411690c0dc832aa7c3860a286ab916