### PR TITLE
Implement token storage and validation

### DIFF
--- a/seed.sql
+++ b/seed.sql
@@ -9,6 +9,15 @@ CREATE TABLE IF NOT EXISTS users (
     role VARCHAR(50) NOT NULL
 );
 
+-- Tokens table
+CREATE TABLE IF NOT EXISTS tokens (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    token VARCHAR(255) NOT NULL UNIQUE,
+    expires_at DATETIME NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
 -- Wallets table
 CREATE TABLE IF NOT EXISTS wallets (
     user_id INT PRIMARY KEY,


### PR DESCRIPTION
## Summary
- add `tokens` table to seed file
- implement token insert when logging in
- query token table for logout, user info and token refresh

## Testing
- `php -l src/Controllers/AuthController.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842a292ab70832a90021263e7411cc8