### PR TITLE
Introduce environment-based config

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,13 @@ BazarTrack-API provides a JSON REST service for a smart purchase and money manag
 - PHP 8.0+
 - MySQL
 
-Update the connection settings in `src/Core/Database.php` before running the API.
+Create a `.env` file (or set environment variables) with your database details before running the API. The `config.php` file automatically loads variables from this file at runtime.
+The following variables are required:
+
+- `DB_HOST` – database host name
+- `DB_NAME` – database name
+- `DB_USER` – database username
+- `DB_PASSWORD` – database password
 
 ## User setup
 

--- a/config.php
+++ b/config.php
@@ -1,0 +1,17 @@
+<?php
+// Simple configuration loader
+// Loads environment variables from a .env file if present.
+
+$envFile = __DIR__ . '/.env';
+if (file_exists($envFile)) {
+    $lines = file($envFile, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+    foreach ($lines as $line) {
+        if (strpos(trim($line), '#') === 0) {
+            continue;
+        }
+        [$name, $value] = array_pad(explode('=', $line, 2), 2, null);
+        if ($name !== null && $value !== null && !isset($_ENV[$name])) {
+            $_ENV[$name] = trim($value);
+        }
+    }
+}

--- a/src/Core/Database.php
+++ b/src/Core/Database.php
@@ -7,11 +7,22 @@ use PDO;
 use PDOException;
 
 class Database {
-    private $host = 'localhost';
-    private $db_name = 'test_db';
-    private $username = 'root';
-    private $password = '';
+    private $host;
+    private $db_name;
+    private $username;
+    private $password;
     private $conn;
+
+    public function __construct()
+    {
+        // Load configuration so environment variables from .env are available
+        require_once __DIR__ . '/../../config.php';
+
+        $this->host = getenv('DB_HOST') ?: 'localhost';
+        $this->db_name = getenv('DB_NAME') ?: 'test_db';
+        $this->username = getenv('DB_USER') ?: 'root';
+        $this->password = getenv('DB_PASSWORD') ?: '';
+    }
 
     public function getConnection() {
         $this->conn = null;


### PR DESCRIPTION
## Summary
- load configuration from `.env` via new `config.php`
- use environment variables in `Database` connection
- document required variables in README

## Testing
- `php -l src/Core/Database.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842a2977624832ab6fdb9bb5f5f7ee6