### PR TITLE
Configure CORS origin from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ php -S localhost:8000 index.php
 
 All requests are routed through `index.php`.
 
+### CORS configuration
+
+Set an environment variable called `CORS_ORIGIN` with the URL allowed to access
+the API. When defined, `index.php` will include an `Access-Control-Allow-Origin`
+header for that origin.
+
 ## Example data
 
 The repository provides `seed.sql` with the full schema and seed rows. It

--- a/index.php
+++ b/index.php
@@ -12,7 +12,10 @@ use App\Controllers\PaymentController;
 use App\Controllers\WalletController;
 use App\Controllers\AnalyticsController;
 
-header("Access-Control-Allow-Origin: *");
+$allowedOrigin = getenv('CORS_ORIGIN');
+if ($allowedOrigin !== false) {
+    header("Access-Control-Allow-Origin: $allowedOrigin");
+}
 header("Content-Type: application/json; charset=UTF-8");
 if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
     header('Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS');


### PR DESCRIPTION
## Summary
- read `CORS_ORIGIN` environment variable
- send `Access-Control-Allow-Origin` only if `CORS_ORIGIN` is defined
- document the `CORS_ORIGIN` environment variable

## Testing
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_b_6842a29894d8832a91b7424615852a5c