### PR TITLE
Update README with auth token usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,48 +74,56 @@ mysql < seed.sql
 
 ## Endpoints
 
+After logging in, include the returned token in requests to secured endpoints using the header:
+
+```text
+Authorization: Bearer <token>
+```
+
+Endpoints annotated with **(🔒 requires token)** need this header.
+
 ### Authentication
 - `POST /api/auth/login` – log in with email and password.
-- `POST /api/auth/logout` – invalidate the current token.
-- `GET /api/auth/me` – return information about the current user.
-- `POST /api/auth/refresh` – issue a new token.
+- `POST /api/auth/logout` – invalidate the current token. **(🔒 requires token)**
+- `GET /api/auth/me` – return information about the current user. **(🔒 requires token)**
+- `POST /api/auth/refresh` – issue a new token. **(🔒 requires token)**
 - *No registration endpoint is provided.*
 
 ### Orders
-- `GET /api/orders` – list orders.
-- `POST /api/orders` – create an order.
-- `GET /api/orders/{id}` – get a specific order.
-- `PUT /api/orders/{id}` – update an order.
-- `DELETE /api/orders/{id}` – delete an order.
-- `POST /api/orders/{id}/assign` – assign an order to a user.
-- `POST /api/orders/{id}/complete` – mark an order as completed.
+- `GET /api/orders` – list orders. **(🔒 requires token)**
+- `POST /api/orders` – create an order. **(🔒 requires token)**
+- `GET /api/orders/{id}` – get a specific order. **(🔒 requires token)**
+- `PUT /api/orders/{id}` – update an order. **(🔒 requires token)**
+- `DELETE /api/orders/{id}` – delete an order. **(🔒 requires token)**
+- `POST /api/orders/{id}/assign` – assign an order to a user. **(🔒 requires token)**
+- `POST /api/orders/{id}/complete` – mark an order as completed. **(🔒 requires token)**
 
 ### Order items
-- `GET /api/order_items` – list all items.
-- `GET /api/order_items/{order_id}` – list items for an order.
-- `GET /api/order_items/{order_id}/{id}` – get a single item.
-- `POST /api/order_items` – create an item.
-- `PUT /api/order_items/{order_id}/{id}` – update an item.
-- `DELETE /api/order_items/{order_id}/{id}` – delete an item.
+- `GET /api/order_items` – list all items. **(🔒 requires token)**
+- `GET /api/order_items/{order_id}` – list items for an order. **(🔒 requires token)**
+- `GET /api/order_items/{order_id}/{id}` – get a single item. **(🔒 requires token)**
+- `POST /api/order_items` – create an item. **(🔒 requires token)**
+- `PUT /api/order_items/{order_id}/{id}` – update an item. **(🔒 requires token)**
+- `DELETE /api/order_items/{order_id}/{id}` – delete an item. **(🔒 requires token)**
 
 ### Payments
-- `GET /api/payments` – list payments.
-- `POST /api/payments` – create a payment.
+- `GET /api/payments` – list payments. **(🔒 requires token)**
+- `POST /api/payments` – create a payment. **(🔒 requires token)**
 
 ### Wallet
-- `GET /api/wallet/{user_id}` – retrieve the balance for a user.
-- `GET /api/wallet/{user_id}/transactions` – list wallet transactions.
+- `GET /api/wallet/{user_id}` – retrieve the balance for a user. **(🔒 requires token)**
+- `GET /api/wallet/{user_id}/transactions` – list wallet transactions. **(🔒 requires token)**
 
 ### History
-- `GET /api/history` – list history logs.
-- `GET /api/history/{entity}/{id}` – logs for a specific entity instance.
-- `POST /api/history` – create a log entry.
-- `DELETE /api/history/{id}` – delete a log entry.
+- `GET /api/history` – list history logs. **(🔒 requires token)**
+- `GET /api/history/{entity}/{id}` – logs for a specific entity instance. **(🔒 requires token)**
+- `POST /api/history` – create a log entry. **(🔒 requires token)**
+- `DELETE /api/history/{id}` – delete a log entry. **(🔒 requires token)**
 
 ### Analytics
-- `GET /api/analytics/dashboard` – basic dashboard statistics.
-- `GET /api/analytics/reports` – monthly reports.
+- `GET /api/analytics/dashboard` – basic dashboard statistics. **(🔒 requires token)**
+- `GET /api/analytics/reports` – monthly reports. **(🔒 requires token)**
 
-Responses are returned in JSON format. Some endpoints expect an authentication token (token handling is simplified in this example).
+Responses are returned in JSON format. Endpoints marked with **(🔒 requires token)** must include the `Authorization` header shown above.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on contributing to this project.


### PR DESCRIPTION
## Summary
- document how to send the authorization token
- mark all protected endpoints in the README

## Testing
- `php -l index.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68482bcec1d4832a909678d16f9175f6