### PR TITLE
Fix auth header check

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -31,6 +31,7 @@ Authenticate a user.
 
 ### `POST /api/auth/logout`
 Invalidate the current token.
+Requires an `Authorization: Bearer <token>` header.
 
 **Response**
 ```json
@@ -41,6 +42,7 @@ Invalidate the current token.
 
 ### `GET /api/auth/me`
 Return basic information about the authenticated user.
+Requires an `Authorization: Bearer <token>` header.
 
 **Response**
 ```json
@@ -54,6 +56,7 @@ Return basic information about the authenticated user.
 
 ### `POST /api/auth/refresh`
 Issue a new token.
+Requires an `Authorization: Bearer <token>` header.
 
 **Response**
 ```json

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -72,7 +72,7 @@ class AuthController {
     public function me() {
         if (!isset($_SERVER['HTTP_AUTHORIZATION'])) {
             ResponseHelper::error(401, 'No token provided.');
-
+            return;
         }
         $tokenValue = str_replace('Bearer ', '', $_SERVER['HTTP_AUTHORIZATION']);
         $token = new Token($this->db);


### PR DESCRIPTION
## Summary
- stop processing /api/auth/me when Authorization header is missing
- document the Authorization header requirement for protected endpoints

## Testing
- `php -l src/Controllers/AuthController.php`

------
https://chatgpt.com/codex/tasks/task_b_68482ca6664c832abe3f525ce59dcc0f