### PR TITLE
Add user info to AuthMiddleware

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -101,12 +101,12 @@ Create a new order. Only users with the `owner` role may create orders.
 }
 ```
 
-**Body parameters**
-- `created_by` – user id of the owner creating the order (required)
+-**Body parameters**
 - `assigned_to` – user id of the assistant the order is assigned to (optional)
 - `status` – order status string (required)
 - `created_at` – datetime string (required)
 - `completed_at` – datetime string (optional)
+The `created_by` value is taken from the authenticated token.
 
 ### `GET /api/orders/{id}`
 Retrieve a single order by id.
@@ -165,7 +165,7 @@ Assign an order to a user.
 
 **Body parameters**
 - `user_id` – id of the user the order will be assigned to
-- `assigned_by` – id of the user performing the assignment
+The assigning user is taken from the authenticated token.
 
 Owners may assign any order; assistants may assign orders to themselves.
 
@@ -182,8 +182,8 @@ Mark an order as completed.
 ```
 
 **Body parameters**
-- `user_id` – id of the assistant completing the order
 - `completed_at` – completion datetime (optional)
+The assistant completing the order is inferred from the authenticated token.
 
 Only assistants can mark orders as completed.
 
@@ -265,7 +265,7 @@ Create a new order item. Only owners can add items.
 - `estimated_cost` – estimated price (optional)
 - `actual_cost` – final price (optional)
 - `status` – item status (required)
-- `user_id` – id of the owner creating the item (required)
+The creating user is taken from the authenticated token.
 
 ### `PUT /api/order_items/{order_id}/{id}`
 Update an order item. Assistants and owners may update items.
@@ -291,7 +291,7 @@ Update an order item. Assistants and owners may update items.
 - `estimated_cost` – estimated price (optional)
 - `actual_cost` – final price (optional)
 - `status` – item status (required)
-- `user_id` – id of the user making the change (required)
+The user performing the update is inferred from the authenticated token.
 
 If `actual_cost` is supplied, the amount is debited from the user's wallet.
 
@@ -306,7 +306,7 @@ Delete an order item. Only owners can delete items.
 ```
 
 **Body parameters**
-- `user_id` – id of the owner deleting the item
+The deleting user is taken from the authenticated token.
 
 ---
 
@@ -347,7 +347,7 @@ Record a payment or expense.
 - `amount` – monetary amount (required)
 - `type` – `credit` or `debit` (required)
 - `created_at` – datetime string (required)
-- `created_by` – id of the user creating the payment (required)
+The `created_by` value comes from the authenticated token.
 
 Credits may only be created by owners, while debits are restricted to assistants. A new payment updates the user's wallet balance and transactions.
 
@@ -446,9 +446,9 @@ Create a history log entry.
 - `entity_type` – type name (required)
 - `entity_id` – entity id (required)
 - `action` – short action description (required)
-- `changed_by_user_id` – id of the user who made the change (required)
 - `timestamp` – datetime string (required)
 - `data_snapshot` – JSON data representing the entity state (required)
+The `changed_by_user_id` value is taken from the authenticated token.
 
 ### `DELETE /api/history/{id}`
 Delete a history log entry.

--- a/src/Controllers/HistoryLogController.php
+++ b/src/Controllers/HistoryLogController.php
@@ -86,7 +86,7 @@ class HistoryLogController {
 
     private function createLog() {
         $data = json_decode(file_get_contents("php://input"), true);
-        $required = ['entity_type', 'entity_id', 'action', 'changed_by_user_id', 'timestamp', 'data_snapshot'];
+        $required = ['entity_type', 'entity_id', 'action', 'timestamp', 'data_snapshot'];
         foreach ($required as $field) {
             if (empty($data[$field])) {
                 ResponseHelper::error(400, "$field is required.");
@@ -94,14 +94,14 @@ class HistoryLogController {
             }
         }
 
-        if (!Validator::validateInt($data['entity_id']) || !Validator::validateInt($data['changed_by_user_id']) || !Validator::validateDate($data['timestamp'])) {
+        if (!Validator::validateInt($data['entity_id']) || !Validator::validateDate($data['timestamp'])) {
             ResponseHelper::error(400, 'Invalid input format.');
             return;
         }
         $this->log->entity_type = $data['entity_type'];
         $this->log->entity_id = $data['entity_id'];
         $this->log->action = $data['action'];
-        $this->log->changed_by_user_id = $data['changed_by_user_id'];
+        $this->log->changed_by_user_id = AuthMiddleware::$userId;
         $this->log->timestamp = $data['timestamp'];
         $this->log->data_snapshot = $data['data_snapshot'];
         if ($this->log->create()) {

--- a/src/Core/AuthMiddleware.php
+++ b/src/Core/AuthMiddleware.php
@@ -5,8 +5,15 @@ use PDO;
 
 class AuthMiddleware
 {
+    public static ?int $userId = null;
+    public static ?string $role = null;
+
     public static function check(): bool
     {
+        if (self::$userId !== null) {
+            return true;
+        }
+
         if (!isset($_SERVER['HTTP_AUTHORIZATION'])) {
             http_response_code(401);
             echo json_encode(['message' => 'Unauthorized']);
@@ -22,7 +29,12 @@ class AuthMiddleware
         $stmt = $db->prepare('SELECT user_id FROM tokens WHERE token = ? LIMIT 1');
         $stmt->bindParam(1, $token);
         $stmt->execute();
-        if ($stmt->rowCount() === 1) {
+        if ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            self::$userId = (int)$row['user_id'];
+            $roleStmt = $db->prepare('SELECT role FROM users WHERE id = ? LIMIT 1');
+            $roleStmt->bindParam(1, self::$userId);
+            $roleStmt->execute();
+            self::$role = $roleStmt->fetch(PDO::FETCH_COLUMN) ?: null;
             return true;
         }
         http_response_code(401);


### PR DESCRIPTION
## Summary
- extend `AuthMiddleware` with static properties to store user ID and role
- set those properties when validating the bearer token
- use those properties in controllers instead of request fields
- update docs for token-based user detection

## Testing
- `php -l src/Core/AuthMiddleware.php` *(fails: command not found)*
- `php -l src/Controllers/OrderController.php` *(fails: command not found)*
- `php -l src/Controllers/OrderItemController.php` *(fails: command not found)*
- `php -l src/Controllers/PaymentController.php` *(fails: command not found)*
- `php -l src/Controllers/HistoryLogController.php` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_6848355023e0832ab440f7ea556e619a