### PR TITLE
Add assistant listing endpoint with optional wallet balance

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -574,6 +574,35 @@ Return monthly order counts and revenue totals.
 ]
 ```
 
+## Assistants
+
+### `GET /api/assistants`
+List assistant users.
+
+**Query parameters**
+- `with_balance` – if `true`, include current wallet balances.
+
+**Response**
+```json
+[
+  {
+    "id": 2,
+    "name": "Assistant Jane"
+  }
+]
+```
+
+**Response with balance**
+```json
+[
+  {
+    "id": 2,
+    "name": "Assistant Jane",
+    "balance": 150.0
+  }
+]
+```
+
 ---
 
 All timestamps follow the `YYYY-MM-DD HH:MM:SS` format and are generated using the `Asia/Dhaka` timezone. Endpoints may return standard HTTP error codes for validation or authorization failures. Error bodies follow the structure shown above.

--- a/index.php
+++ b/index.php
@@ -16,6 +16,7 @@ use App\Controllers\HistoryLogController;
 use App\Controllers\PaymentController;
 use App\Controllers\WalletController;
 use App\Controllers\AnalyticsController;
+use App\Controllers\AssistantController;
 use App\Core\ResponseHelper;
 
 $allowedOrigin = $_ENV['ALLOWED_ORIGIN'];
@@ -149,6 +150,12 @@ switch ($resource) {
             } else {
                 ResponseHelper::error(404, 'Endpoint not found.');
             }
+            break;
+        }
+        // /api/assistants
+        if ($second === 'assistants') {
+            $assistantController = new AssistantController();
+            $assistantController->processRequest($method);
             break;
         }
         // Fallback

--- a/src/Controllers/AssistantController.php
+++ b/src/Controllers/AssistantController.php
@@ -1,0 +1,53 @@
+<?php
+// File: src/Controllers/AssistantController.php
+
+namespace App\Controllers;
+
+use App\Core\Database;
+use App\Models\User;
+use App\Core\ResponseHelper;
+use PDO;
+use App\Core\AuthMiddleware;
+
+class AssistantController {
+    private $db;
+    private $user;
+
+    public function __construct() {
+        $database = new Database();
+        $this->db = $database->getConnection();
+        $this->user = new User($this->db);
+    }
+
+    public function processRequest($method) {
+        if (!AuthMiddleware::check()) {
+            return;
+        }
+        switch ($method) {
+            case 'GET':
+                $includeBalance = isset($_GET['with_balance']) && in_array($_GET['with_balance'], ['1', 'true'], true);
+                $this->getAssistants($includeBalance);
+                break;
+            default:
+                ResponseHelper::error(405, 'Method not allowed.');
+                break;
+        }
+    }
+
+    private function getAssistants($includeBalance) {
+        $stmt = $this->user->readAssistants($includeBalance);
+        $assistants = [];
+        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            $assistant = [
+                'id' => $row['id'],
+                'name' => $row['name'],
+            ];
+            if ($includeBalance) {
+                $assistant['balance'] = $row['balance'];
+            }
+            $assistants[] = $assistant;
+        }
+        echo json_encode($assistants);
+    }
+}
+

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -25,6 +25,18 @@ class User {
         return $stmt;
     }
 
+    public function readAssistants(bool $includeBalance = false)
+    {
+        if ($includeBalance) {
+            $query = "SELECT u.id, u.name, COALESCE(w.balance, 0) AS balance FROM {$this->table_name} u LEFT JOIN wallets w ON u.id = w.user_id WHERE u.role = 'assistant'";
+        } else {
+            $query = "SELECT id, name FROM {$this->table_name} WHERE role = 'assistant'";
+        }
+        $stmt = $this->conn->prepare($query);
+        $stmt->execute();
+        return $stmt;
+    }
+
     public function readOne() {
         $query = "SELECT id, name, email, role FROM " . $this->table_name . " WHERE id = ? LIMIT 1";
         $stmt = $this->conn->prepare($query);


### PR DESCRIPTION
## Summary
- add AssistantController and router wiring for `/api/assistants`
- support optional `with_balance` query to include wallet balances
- document new assistants endpoint

## Testing
- `php -l src/Models/User.php`
- `php -l src/Controllers/AssistantController.php`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_b_689978359a0c832a9d01c88c1420343b