### PR TITLE
Allow assistants to fetch unassigned orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Endpoints annotated with **(🔒 requires token)** need this header.
 - *No registration endpoint is provided.*
 
 ### Orders
-- `GET /api/orders` – list orders. **(🔒 requires token)**
+- `GET /api/orders` – list orders. Supports `status` and `assigned_to` query parameters (`assigned_to=null` for unassigned). **(🔒 requires token)**
 - `POST /api/orders` – create an order. **(🔒 requires token)**
 - `GET /api/orders/{id}` – get a specific order. **(🔒 requires token)**
 - `PUT /api/orders/{id}` – update an order. **(🔒 requires token)**
@@ -107,7 +107,7 @@ Endpoints annotated with **(🔒 requires token)** need this header.
 - `DELETE /api/order_items/{order_id}/{id}` – delete an item. **(🔒 requires token)**
 
 ### Payments
-- `GET /api/payments` – list payments. **(🔒 requires token)**
+- `GET /api/payments` – list payments. Supports `user_id`, `type`, `from`, and `to` filters. **(🔒 requires token)**
 - `POST /api/payments` – create a payment. **(🔒 requires token)**
 
 ### Wallet
@@ -115,7 +115,7 @@ Endpoints annotated with **(🔒 requires token)** need this header.
 - `GET /api/wallet/{user_id}/transactions` – list wallet transactions. **(🔒 requires token)**
 
 ### History
-- `GET /api/history` – list history logs. **(🔒 requires token)**
+- `GET /api/history` – list history logs. Supports a `changed_by` filter. **(🔒 requires token)**
 - `GET /api/history/{entity}/{id}` – logs for a specific entity instance. **(🔒 requires token)**
 - `POST /api/history` – create a log entry. **(🔒 requires token)**
 - `DELETE /api/history/{id}` – delete a log entry. **(🔒 requires token)**
@@ -123,6 +123,7 @@ Endpoints annotated with **(🔒 requires token)** need this header.
 ### Analytics
 - `GET /api/analytics/dashboard` – basic dashboard statistics. **(🔒 requires token)**
 - `GET /api/analytics/reports` – monthly reports. **(🔒 requires token)**
+- `GET /api/analytics/assistants/{id}` – per-assistant summary. **(🔒 requires token)**
 
 ## Example workflow
 

--- a/docs.md
+++ b/docs.md
@@ -115,6 +115,10 @@ Requires an `Authorization: Bearer <token>` header.
 ### `GET /api/orders`
 List all orders.
 
+**Query parameters**
+- `status` – filter by order status.
+- `assigned_to` – assistant user id. Use `assigned_to=null` to retrieve unassigned orders. If omitted, all orders are returned.
+
 **Response**
 ```json
 [
@@ -394,6 +398,12 @@ The deleting user is taken from the authenticated token.
 ### `GET /api/payments`
 List recorded payments.
 
+**Query parameters**
+- `user_id` – filter by wallet owner.
+- `type` – `credit` or `debit`.
+- `from` – inclusive start date (`YYYY-MM-DD`).
+- `to` – inclusive end date (`YYYY-MM-DD`).
+
 **Response**
 ```json
 [
@@ -474,6 +484,9 @@ List wallet transactions for a user in reverse chronological order.
 
 ### `GET /api/history`
 List all history log entries.
+
+**Query parameters**
+- `changed_by` – filter by the user id that performed the action.
 
 **Response**
 ```json
@@ -572,6 +585,25 @@ Return monthly order counts and revenue totals.
     "revenue": 1000.0
   }
 ]
+```
+
+### `GET /api/analytics/assistants/{id}`
+Return per-assistant order and revenue totals along with monthly trends.
+
+**Response**
+```json
+{
+  "total_orders": 5,
+  "total_revenue": 250.0,
+  "orders_by_month": [
+    { "month": "2024-01", "count": 3 },
+    { "month": "2024-02", "count": 2 }
+  ],
+  "revenue_by_month": [
+    { "month": "2024-01", "revenue": 150.0 },
+    { "month": "2024-02", "revenue": 100.0 }
+  ]
+}
 ```
 
 ## Assistants

--- a/index.php
+++ b/index.php
@@ -140,13 +140,15 @@ switch ($resource) {
             }
             break;
         }
-        // /api/analytics/dashboard and /api/analytics/reports
+        // /api/analytics/*
         if ($second === 'analytics') {
             $analyticsController = new AnalyticsController();
             if ($third === 'dashboard' && $method === 'GET') {
                 $analyticsController->dashboard();
             } elseif ($third === 'reports' && $method === 'GET') {
                 $analyticsController->reports();
+            } elseif ($third === 'assistants' && $fourth && $method === 'GET') {
+                $analyticsController->assistantSummary($fourth);
             } else {
                 ResponseHelper::error(404, 'Endpoint not found.');
             }

--- a/src/Controllers/HistoryLogController.php
+++ b/src/Controllers/HistoryLogController.php
@@ -49,7 +49,16 @@ class HistoryLogController {
     }
 
     private function getLogs() {
-        $stmt = $this->log->readAll();
+        $changedBy = $_GET['changed_by'] ?? null;
+        if ($changedBy !== null) {
+            if (!Validator::validateInt($changedBy)) {
+                ResponseHelper::error(400, 'Invalid user ID.');
+                return;
+            }
+            $stmt = $this->log->readByUser((int)$changedBy);
+        } else {
+            $stmt = $this->log->readAll();
+        }
         $logs_arr = [];
         while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
             $logs_arr[] = [

--- a/src/Controllers/OrderController.php
+++ b/src/Controllers/OrderController.php
@@ -73,7 +73,28 @@ class OrderController {
     }
 
     private function getOrders() {
-        $stmt = $this->order->readAll();
+        $status = $_GET['status'] ?? null;
+        $assignedToRaw = $_GET['assigned_to'] ?? null;
+
+        $filters = [];
+        if ($status !== null) {
+            $filters['status'] = $status;
+        }
+
+        if ($assignedToRaw !== null && $assignedToRaw !== '') {
+            $normalized = strtolower($assignedToRaw);
+            if (in_array($normalized, ['null', 'none', 'unassigned'], true)) {
+                $filters['assigned_to'] = null;
+            } else {
+                if (!Validator::validateInt($assignedToRaw)) {
+                    ResponseHelper::error(400, 'Invalid assigned_to.');
+                    return;
+                }
+                $filters['assigned_to'] = (int)$assignedToRaw;
+            }
+        }
+
+        $stmt = $this->order->readAll($filters);
         $orders_arr = [];
         while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
             $orders_arr[] = [

--- a/src/Controllers/PaymentController.php
+++ b/src/Controllers/PaymentController.php
@@ -44,7 +44,25 @@ class PaymentController {
     }
 
     private function getPayments() {
-        $stmt = $this->payment->readAll();
+        $filters = [];
+        if (isset($_GET['user_id'])) {
+            if (!Validator::validateInt($_GET['user_id'])) {
+                ResponseHelper::error(400, 'Invalid user_id.');
+                return;
+            }
+            $filters['user_id'] = (int)$_GET['user_id'];
+        }
+        if (isset($_GET['type'])) {
+            $filters['type'] = $_GET['type'];
+        }
+        if (isset($_GET['from'])) {
+            $filters['from'] = $_GET['from'];
+        }
+        if (isset($_GET['to'])) {
+            $filters['to'] = $_GET['to'];
+        }
+
+        $stmt = $this->payment->readAll($filters);
         $payments_arr = [];
         while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
             $payments_arr[] = [

--- a/src/Core/ResponseHelper.php
+++ b/src/Core/ResponseHelper.php
@@ -5,7 +5,9 @@ class ResponseHelper
 {
     public static function error(int $status, string $message, ?string $errorCode = null): void
     {
-        http_response_code($status);
+        if (!headers_sent()) {
+            http_response_code($status);
+        }
         echo json_encode([
             'error' => $errorCode ?? (string)$status,
             'msg' => $message,
@@ -15,7 +17,9 @@ class ResponseHelper
 
     public static function success(string $message, $data = null, int $status = 200): void
     {
-        http_response_code($status);
+        if (!headers_sent()) {
+            http_response_code($status);
+        }
         echo json_encode([
             'error' => null,
             'msg' => $message,

--- a/src/Models/HistoryLog.php
+++ b/src/Models/HistoryLog.php
@@ -29,6 +29,14 @@ class HistoryLog {
         return $stmt;
     }
 
+    public function readByUser($userId) {
+        $query = "SELECT id, entity_type, entity_id, action, changed_by_user_id, timestamp, data_snapshot FROM " . $this->table_name . " WHERE changed_by_user_id = :user_id";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(':user_id', $userId, PDO::PARAM_INT);
+        $stmt->execute();
+        return $stmt;
+    }
+
     public function readByEntity() {
         $query = "SELECT id, entity_type, entity_id, action, changed_by_user_id, timestamp, data_snapshot FROM " . $this->table_name . " WHERE entity_type = ? AND entity_id = ?";
         $stmt = $this->conn->prepare($query);

--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -21,9 +21,30 @@ class Order {
         $this->conn = $db;
     }
 
-    public function readAll() {
+    public function readAll(array $filters = []) {
         $query = "SELECT id, created_by, assigned_to, status, created_at, completed_at FROM " . $this->table_name;
+        $conditions = [];
+        $params = [];
+
+        if (isset($filters['status'])) {
+            $conditions[] = "status = :status";
+            $params[':status'] = $filters['status'];
+        }
+        if (array_key_exists('assigned_to', $filters)) {
+            if ($filters['assigned_to'] === null) {
+                $conditions[] = "assigned_to IS NULL";
+            } else {
+                $conditions[] = "assigned_to = :assigned_to";
+                $params[':assigned_to'] = $filters['assigned_to'];
+            }
+        }
+        if ($conditions) {
+            $query .= " WHERE " . implode(" AND ", $conditions);
+        }
         $stmt = $this->conn->prepare($query);
+        foreach ($params as $key => $value) {
+            $stmt->bindValue($key, $value);
+        }
         $stmt->execute();
         return $stmt;
     }

--- a/src/Models/Payment.php
+++ b/src/Models/Payment.php
@@ -19,9 +19,33 @@ class Payment {
         $this->conn = $db;
     }
 
-    public function readAll() {
+    public function readAll(array $filters = []) {
         $query = "SELECT id, user_id, amount, type, created_at FROM " . $this->table_name;
+        $conditions = [];
+        $params = [];
+        if (isset($filters['user_id'])) {
+            $conditions[] = "user_id = :user_id";
+            $params[':user_id'] = $filters['user_id'];
+        }
+        if (isset($filters['type'])) {
+            $conditions[] = "type = :type";
+            $params[':type'] = $filters['type'];
+        }
+        if (isset($filters['from'])) {
+            $conditions[] = "created_at >= :from";
+            $params[':from'] = $filters['from'];
+        }
+        if (isset($filters['to'])) {
+            $conditions[] = "created_at <= :to";
+            $params[':to'] = $filters['to'];
+        }
+        if ($conditions) {
+            $query .= " WHERE " . implode(" AND ", $conditions);
+        }
         $stmt = $this->conn->prepare($query);
+        foreach ($params as $key => $value) {
+            $stmt->bindValue($key, $value);
+        }
         $stmt->execute();
         return $stmt;
     }


### PR DESCRIPTION
## Summary
- Stop auto-defaulting `assigned_to` to the authenticated assistant
- Document optional `assigned_to` filtering and `assigned_to=null` behavior

## Testing
- `phpunit --testdox tests` *(fails: Cannot open file "tests")*

------
https://chatgpt.com/codex/tasks/task_b_689ff4f6bf40832ab9446440693ef4ea