### PR TITLE
Enable history log retrieval by entity type

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Endpoints annotated with **(🔒 requires token)** need this header.
 
 ### History
 - `GET /api/history` – list history logs. Supports a `changed_by` filter. **(🔒 requires token)**
+- `GET /api/history/{entity}` – logs for all instances of a given entity type. **(🔒 requires token)**
 - `GET /api/history/{entity}/{id}` – logs for a specific entity instance. **(🔒 requires token)**
 - `POST /api/history` – create a log entry. **(🔒 requires token)**
 - `DELETE /api/history/{id}` – delete a log entry. **(🔒 requires token)**
@@ -149,7 +150,7 @@ scenario:
 
 5. **Completion and auditing**
    - When work is done, call `POST /api/orders/{id}/complete`.
-   - Activity timelines are available from `GET /api/history/order/{id}`.
+   - Activity timelines are available from `GET /api/history/order/{id}` or all order logs with `GET /api/history/order`.
    - Owners can view overall statistics using `GET /api/analytics/dashboard`.
 
 Responses are returned in JSON format. Endpoints marked with **(🔒 requires token)** must include the `Authorization` header shown above.

--- a/docs.md
+++ b/docs.md
@@ -9,7 +9,7 @@ The API supports an owner–assistant purchasing workflow. The list below shows 
 ### Owner dashboard
 - **Stats (total, assigned, in progress, completed)** – `GET /api/analytics/dashboard` returns aggregated counts, and `GET /api/orders` lists all orders for client-side filtering.
 - **Assistant wallet summary & advance history** – `GET /api/wallet/{assistant_id}` for current balance and `GET /api/wallet/{assistant_id}/transactions` for advances and expenses.
-- **Order activity timeline** – `GET /api/history/order/{order_id}` shows a chronological log for a specific order.
+- **Order activity timeline** – `GET /api/history/order/{order_id}` shows a chronological log for a specific order, or `GET /api/history/order` lists logs for all orders.
 
 ### Assistant dashboard
 - **Assigned orders** – `GET /api/orders` with client-side filtering by `assigned_to` or `status`.
@@ -18,7 +18,7 @@ The API supports an owner–assistant purchasing workflow. The list below shows 
 ### Purchase entry / order detail
 - **Update item status and costs** – `PUT /api/order_items/{order_id}/{item_id}`.
 - **Record expenses or advances** – `POST /api/payments` with `type` set to `debit` or `credit`.
-- **Timeline and action log** – actions are stored via `POST /api/history` and retrievable with `GET /api/history/order/{order_id}`.
+- **Timeline and action log** – actions are stored via `POST /api/history` and retrievable with `GET /api/history/order/{order_id}` or `GET /api/history/order` for all orders.
 
 ### Order Management
 - **Create order** – Owner makes a new order and can submit initial line items in the same request using POST /api/orders
@@ -31,7 +31,7 @@ The API supports an owner–assistant purchasing workflow. The list below shows 
 - **Automatic adjustments** – When an assistant supplies actual_cost for an item via PUT /api/order_items/{order_id}/{id}, the wallet is adjusted by the difference from the previous actual_cost (debit if the cost increases, credit if it decreases) and a transaction is logged
 
 ### Activity Timeline & Logging
-- **History logging** – Any action (order creation, item updates, assignments, etc.) can be recorded via POST /api/history, and individual entity timelines are retrieved with GET /api/history/{entity}/{id}
+- **History logging** – Any action (order creation, item updates, assignments, etc.) can be recorded via POST /api/history, and individual entity timelines are retrieved with `GET /api/history/{entity}/{id}` or all logs of a type with `GET /api/history/{entity}`.
 - These endpoints allow building the “Order Activity Timeline” and “Action Log” views you described.
 
 ### Dashboards & Analytics
@@ -43,7 +43,7 @@ The API supports an owner–assistant purchasing workflow. The list below shows 
 3. Assistant self-assigns or is assigned – `POST /api/orders/{id}/assign`.
 4. Assistant updates item costs – `PUT /api/order_items/{order_id}/{item_id}` and logs expenses with `POST /api/payments` (`debit`).
 5. System logs each action – `POST /api/history`.
-6. Owner reviews the timeline – `GET /api/history/order/{id}`.
+6. Owner reviews the timeline – `GET /api/history/order/{id}` or all order logs with `GET /api/history/order`.
 
 Error responses share a common structure:
 ```json
@@ -487,6 +487,23 @@ List all history log entries.
 
 **Query parameters**
 - `changed_by` – filter by the user id that performed the action.
+
+**Response**
+```json
+[
+  {
+    "id": 1,
+    "entity_type": "order",
+    "entity_id": 1,
+    "action": "created",
+    "changed_by_user_id": 1,
+    "timestamp": "2024-01-03 09:00:00"
+  }
+]
+```
+
+### `GET /api/history/{entity}`
+List log entries for all records of a given entity type (e.g. `order`).
 
 **Response**
 ```json

--- a/index.php
+++ b/index.php
@@ -130,11 +130,13 @@ switch ($resource) {
             }
             break;
         }
-        // /api/history/:entity_type/:entity_id
+        // /api/history/:entity_type/:entity_id and /api/history/:entity_type
         if ($second === 'history') {
             $historyController = new HistoryLogController();
-            if ($third && $fourth) {
+            if ($third !== null && $fourth !== null) {
                 $historyController->processRequest($method, null, $third, $fourth);
+            } elseif ($third !== null) {
+                $historyController->processRequest($method, null, $third);
             } else {
                 $historyController->processRequest($method);
             }

--- a/src/Models/HistoryLog.php
+++ b/src/Models/HistoryLog.php
@@ -37,11 +37,19 @@ class HistoryLog {
         return $stmt;
     }
 
+    public function readByEntityType() {
+        $query = "SELECT id, entity_type, entity_id, action, changed_by_user_id, timestamp, data_snapshot FROM " . $this->table_name . " WHERE entity_type = ?";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(1, $this->entity_type, PDO::PARAM_STR);
+        $stmt->execute();
+        return $stmt;
+    }
+
     public function readByEntity() {
         $query = "SELECT id, entity_type, entity_id, action, changed_by_user_id, timestamp, data_snapshot FROM " . $this->table_name . " WHERE entity_type = ? AND entity_id = ?";
         $stmt = $this->conn->prepare($query);
-        $stmt->bindParam(1, $this->entity_type);
-        $stmt->bindParam(2, $this->entity_id);
+        $stmt->bindParam(1, $this->entity_type, PDO::PARAM_STR);
+        $stmt->bindParam(2, $this->entity_id, PDO::PARAM_INT);
         $stmt->execute();
         return $stmt;
     }


### PR DESCRIPTION
## Summary
- cast entity IDs and bind types for history log lookups
- document entity-type-only history endpoints and update workflow descriptions

## Testing
- `php -l index.php`
- `php -l src/Controllers/HistoryLogController.php`
- `php -l src/Models/HistoryLog.php`
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68a00bb1a928832a825c43b49578eaf7