### PR TITLE
feat: add cursor based pagination

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -50,6 +50,13 @@ Error responses share a common structure:
 { "error": "<message>" }
 ```
 
+## Pagination
+
+List endpoints support cursor-based pagination.
+Use the `limit` query parameter to control page size (maximum 30, default 30)
+and `cursor` to supply the last seen primary key value. Results are returned
+in descending order by ID and contain items with IDs less than the cursor.
+
 ## Authentication
 
 ### `POST /api/auth/login`
@@ -118,6 +125,8 @@ List all orders.
 **Query parameters**
 - `status` – filter by order status.
 - `assigned_to` – assistant user id. Use `assigned_to=null` to retrieve unassigned orders. If omitted, all orders are returned.
+- `limit` – number of records to return (max 30).
+- `cursor` – return records with IDs less than this value.
 
 **Response**
 ```json
@@ -277,6 +286,10 @@ Only assistants can mark orders as completed.
 ### `GET /api/order_items`
 List all order items.
 
+**Query parameters**
+- `limit` – number of records to return (max 30).
+- `cursor` – return records with IDs less than this value.
+
 **Response**
 ```json
 [
@@ -293,6 +306,10 @@ List all order items.
 
 ### `GET /api/order_items/{order_id}`
 List items for a specific order.
+
+**Query parameters**
+- `limit` – number of records to return (max 30).
+- `cursor` – return records with IDs less than this value.
 
 **Response**
 ```json
@@ -403,6 +420,8 @@ List recorded payments.
 - `type` – `credit` or `debit`.
 - `from` – inclusive start date (`YYYY-MM-DD`).
 - `to` – inclusive end date (`YYYY-MM-DD`).
+- `limit` – number of records to return (max 30).
+- `cursor` – return records with IDs less than this value.
 
 **Response**
 ```json
@@ -458,6 +477,10 @@ Return the wallet balance for a user.
 ### `GET /api/wallet/{user_id}/transactions`
 List wallet transactions for a user in reverse chronological order.
 
+**Query parameters**
+- `limit` – number of records to return (max 30).
+- `cursor` – return records with IDs less than this value.
+
 **Response**
 ```json
 [
@@ -487,6 +510,8 @@ List all history log entries.
 
 **Query parameters**
 - `changed_by` – filter by the user id that performed the action.
+- `limit` – number of records to return (max 30).
+- `cursor` – return records with IDs less than this value.
 
 **Response**
 ```json
@@ -505,6 +530,10 @@ List all history log entries.
 ### `GET /api/history/{entity}`
 List log entries for all records of a given entity type (e.g. `order`).
 
+**Query parameters**
+- `limit` – number of records to return (max 30).
+- `cursor` – return records with IDs less than this value.
+
 **Response**
 ```json
 [
@@ -521,6 +550,10 @@ List log entries for all records of a given entity type (e.g. `order`).
 
 ### `GET /api/history/{entity}/{id}`
 List log entries related to a particular entity (e.g. `order`).
+
+**Query parameters**
+- `limit` – number of records to return (max 30).
+- `cursor` – return records with IDs less than this value.
 
 **Response**
 ```json
@@ -630,6 +663,8 @@ List assistant users.
 
 **Query parameters**
 - `with_balance` – if `true`, include current wallet balances.
+- `limit` – number of records to return (max 30).
+- `cursor` – return records with IDs less than this value.
 
 **Response**
 ```json

--- a/src/Controllers/AssistantController.php
+++ b/src/Controllers/AssistantController.php
@@ -35,7 +35,8 @@ class AssistantController {
     }
 
     private function getAssistants($includeBalance) {
-        $stmt = $this->user->readAssistants($includeBalance);
+        [$limit, $cursor] = \App\Core\Pagination::getParams();
+        $stmt = $this->user->readAssistants($includeBalance, $limit, $cursor);
         $assistants = [];
         while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
             $assistant = [

--- a/src/Controllers/HistoryLogController.php
+++ b/src/Controllers/HistoryLogController.php
@@ -56,14 +56,15 @@ class HistoryLogController {
 
     private function getLogs() {
         $changedBy = $_GET['changed_by'] ?? null;
+        [$limit, $cursor] = \App\Core\Pagination::getParams();
         if ($changedBy !== null) {
             if (!Validator::validateInt($changedBy)) {
                 ResponseHelper::error(400, 'Invalid user ID.');
                 return;
             }
-            $stmt = $this->log->readByUser((int)$changedBy);
+            $stmt = $this->log->readByUser((int)$changedBy, $limit, $cursor);
         } else {
-            $stmt = $this->log->readAll();
+            $stmt = $this->log->readAll($limit, $cursor);
         }
         $logs_arr = [];
         while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
@@ -82,7 +83,8 @@ class HistoryLogController {
 
     private function getLogsByEntityType($type) {
         $this->log->entity_type = $type;
-        $stmt = $this->log->readByEntityType();
+        [$limit, $cursor] = \App\Core\Pagination::getParams();
+        $stmt = $this->log->readByEntityType($limit, $cursor);
         $logs_arr = [];
         while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
             $logs_arr[] = [
@@ -101,7 +103,8 @@ class HistoryLogController {
     private function getLogsByEntity($type, $entityId) {
         $this->log->entity_type = $type;
         $this->log->entity_id = (int)$entityId;
-        $stmt = $this->log->readByEntity();
+        [$limit, $cursor] = \App\Core\Pagination::getParams();
+        $stmt = $this->log->readByEntity($limit, $cursor);
         $logs_arr = [];
         while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
             $logs_arr[] = [

--- a/src/Controllers/OrderController.php
+++ b/src/Controllers/OrderController.php
@@ -93,8 +93,8 @@ class OrderController {
                 $filters['assigned_to'] = (int)$assignedToRaw;
             }
         }
-
-        $stmt = $this->order->readAll($filters);
+        [$limit, $cursor] = \App\Core\Pagination::getParams();
+        $stmt = $this->order->readAll($filters, $limit, $cursor);
         $orders_arr = [];
         while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
             $orders_arr[] = [

--- a/src/Controllers/OrderItemController.php
+++ b/src/Controllers/OrderItemController.php
@@ -65,7 +65,8 @@ class OrderItemController {
     }
 
     private function getItems() {
-        $stmt = $this->item->readAll();
+        [$limit, $cursor] = \App\Core\Pagination::getParams();
+        $stmt = $this->item->readAll($limit, $cursor);
         $items_arr = [];
         while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
             $items_arr[] = [
@@ -88,7 +89,8 @@ class OrderItemController {
             return;
         }
         $this->item->order_id = $orderId;
-        $stmt = $this->item->readByOrder();
+        [$limit, $cursor] = \App\Core\Pagination::getParams();
+        $stmt = $this->item->readByOrder($limit, $cursor);
         $items_arr = [];
         while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
             $items_arr[] = [

--- a/src/Controllers/PaymentController.php
+++ b/src/Controllers/PaymentController.php
@@ -62,7 +62,8 @@ class PaymentController {
             $filters['to'] = $_GET['to'];
         }
 
-        $stmt = $this->payment->readAll($filters);
+        [$limit, $cursor] = \App\Core\Pagination::getParams();
+        $stmt = $this->payment->readAll($filters, $limit, $cursor);
         $payments_arr = [];
         while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
             $payments_arr[] = [

--- a/src/Controllers/UserController.php
+++ b/src/Controllers/UserController.php
@@ -44,7 +44,8 @@ class UserController {
     }
 
     private function getUsers() {
-        $stmt = $this->user->readAll();
+        [$limit, $cursor] = \App\Core\Pagination::getParams();
+        $stmt = $this->user->readAll($limit, $cursor);
         $users_arr = [];
         while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
             $users_arr[] = [

--- a/src/Controllers/WalletController.php
+++ b/src/Controllers/WalletController.php
@@ -68,7 +68,8 @@ class WalletController {
             return;
         }
 
-        $stmt = $this->wallet->readTransactions($user_id);
+        [$limit, $cursor] = \App\Core\Pagination::getParams();
+        $stmt = $this->wallet->readTransactions($user_id, $limit, $cursor);
         $transactions_arr = [];
         while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
             $transactions_arr[] = [

--- a/src/Core/Pagination.php
+++ b/src/Core/Pagination.php
@@ -1,0 +1,24 @@
+<?php
+namespace App\Core;
+
+class Pagination
+{
+    public static function getParams(): array
+    {
+        $limit = $_GET['limit'] ?? 30;
+        if (!Validator::validateInt($limit) || (int)$limit <= 0) {
+            $limit = 30;
+        } else {
+            $limit = min((int)$limit, 30);
+        }
+
+        $cursor = $_GET['cursor'] ?? null;
+        if ($cursor !== null && !Validator::validateInt($cursor)) {
+            $cursor = null;
+        } elseif ($cursor !== null) {
+            $cursor = (int)$cursor;
+        }
+
+        return [$limit, $cursor];
+    }
+}

--- a/src/Models/HistoryLog.php
+++ b/src/Models/HistoryLog.php
@@ -22,34 +22,66 @@ class HistoryLog {
         $this->conn = $db;
     }
 
-    public function readAll() {
+    public function readAll(int $limit = 30, ?int $cursor = null) {
         $query = "SELECT id, entity_type, entity_id, action, changed_by_user_id, timestamp, data_snapshot FROM " . $this->table_name;
+        if ($cursor !== null) {
+            $query .= " WHERE id < :cursor";
+        }
+        $query .= " ORDER BY id DESC LIMIT :limit";
         $stmt = $this->conn->prepare($query);
+        if ($cursor !== null) {
+            $stmt->bindValue(':cursor', $cursor, PDO::PARAM_INT);
+        }
+        $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
         $stmt->execute();
         return $stmt;
     }
 
-    public function readByUser($userId) {
+    public function readByUser($userId, int $limit = 30, ?int $cursor = null) {
         $query = "SELECT id, entity_type, entity_id, action, changed_by_user_id, timestamp, data_snapshot FROM " . $this->table_name . " WHERE changed_by_user_id = :user_id";
+        if ($cursor !== null) {
+            $query .= " AND id < :cursor";
+        }
+        $query .= " ORDER BY id DESC LIMIT :limit";
         $stmt = $this->conn->prepare($query);
         $stmt->bindParam(':user_id', $userId, PDO::PARAM_INT);
+        if ($cursor !== null) {
+            $stmt->bindValue(':cursor', $cursor, PDO::PARAM_INT);
+        }
+        $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
         $stmt->execute();
         return $stmt;
     }
 
-    public function readByEntityType() {
-        $query = "SELECT id, entity_type, entity_id, action, changed_by_user_id, timestamp, data_snapshot FROM " . $this->table_name . " WHERE entity_type = ?";
+    public function readByEntityType(int $limit = 30, ?int $cursor = null) {
+        $query = "SELECT id, entity_type, entity_id, action, changed_by_user_id, timestamp, data_snapshot FROM " . $this->table_name . " WHERE entity_type = :entity_type";
+        if ($cursor !== null) {
+            $query .= " AND id < :cursor";
+        }
+        $query .= " ORDER BY id DESC LIMIT :limit";
         $stmt = $this->conn->prepare($query);
-        $stmt->bindParam(1, $this->entity_type, PDO::PARAM_STR);
+        $stmt->bindParam(':entity_type', $this->entity_type, PDO::PARAM_STR);
+        if ($cursor !== null) {
+            $stmt->bindValue(':cursor', $cursor, PDO::PARAM_INT);
+        }
+        $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
         $stmt->execute();
         return $stmt;
     }
 
-    public function readByEntity() {
-        $query = "SELECT id, entity_type, entity_id, action, changed_by_user_id, timestamp, data_snapshot FROM " . $this->table_name . " WHERE entity_type = ? AND entity_id = ?";
+    public function readByEntity(int $limit = 30, ?int $cursor = null) {
+        $query = "SELECT id, entity_type, entity_id, action, changed_by_user_id, timestamp, data_snapshot FROM " . $this->table_name . " WHERE entity_type = :entity_type AND entity_id = :entity_id";
+        if ($cursor !== null) {
+            $query .= " AND id < :cursor";
+        }
+        $query .= " ORDER BY id DESC LIMIT :limit";
         $stmt = $this->conn->prepare($query);
-        $stmt->bindParam(1, $this->entity_type, PDO::PARAM_STR);
-        $stmt->bindParam(2, $this->entity_id, PDO::PARAM_INT);
+        $stmt->bindParam(':entity_type', $this->entity_type, PDO::PARAM_STR);
+        $stmt->bindParam(':entity_id', $this->entity_id, PDO::PARAM_INT);
+        if ($cursor !== null) {
+            $stmt->bindValue(':cursor', $cursor, PDO::PARAM_INT);
+        }
+        $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
         $stmt->execute();
         return $stmt;
     }

--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -21,7 +21,7 @@ class Order {
         $this->conn = $db;
     }
 
-    public function readAll(array $filters = []) {
+    public function readAll(array $filters = [], int $limit = 30, ?int $cursor = null) {
         $query = "SELECT id, created_by, assigned_to, status, created_at, completed_at FROM " . $this->table_name;
         $conditions = [];
         $params = [];
@@ -38,13 +38,19 @@ class Order {
                 $params[':assigned_to'] = $filters['assigned_to'];
             }
         }
+        if ($cursor !== null) {
+            $conditions[] = "id < :cursor";
+            $params[':cursor'] = $cursor;
+        }
         if ($conditions) {
             $query .= " WHERE " . implode(" AND ", $conditions);
         }
+        $query .= " ORDER BY id DESC LIMIT :limit";
         $stmt = $this->conn->prepare($query);
         foreach ($params as $key => $value) {
             $stmt->bindValue($key, $value);
         }
+        $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
         $stmt->execute();
         return $stmt;
     }

--- a/src/Models/OrderItem.php
+++ b/src/Models/OrderItem.php
@@ -23,10 +23,17 @@ class OrderItem {
         $this->conn = $db;
     }
 
-    public function readAll() {
-        $query = "SELECT id, order_id, product_name, quantity, unit, estimated_cost, actual_cost, status
-                  FROM {$this->table_name}";
+    public function readAll(int $limit = 30, ?int $cursor = null) {
+        $query = "SELECT id, order_id, product_name, quantity, unit, estimated_cost, actual_cost, status FROM {$this->table_name}";
+        if ($cursor !== null) {
+            $query .= " WHERE id < :cursor";
+        }
+        $query .= " ORDER BY id DESC LIMIT :limit";
         $stmt = $this->conn->prepare($query);
+        if ($cursor !== null) {
+            $stmt->bindValue(':cursor', $cursor, PDO::PARAM_INT);
+        }
+        $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
         $stmt->execute();
         return $stmt;
     }
@@ -41,12 +48,18 @@ class OrderItem {
         return $stmt;
     }
 
-    public function readByOrder() {
-        $query = "SELECT id, order_id, product_name, quantity, unit, estimated_cost, actual_cost, status
-                  FROM {$this->table_name}
-                  WHERE order_id = ?";
+    public function readByOrder(int $limit = 30, ?int $cursor = null) {
+        $query = "SELECT id, order_id, product_name, quantity, unit, estimated_cost, actual_cost, status FROM {$this->table_name} WHERE order_id = :order_id";
+        if ($cursor !== null) {
+            $query .= " AND id < :cursor";
+        }
+        $query .= " ORDER BY id DESC LIMIT :limit";
         $stmt = $this->conn->prepare($query);
-        $stmt->bindParam(1, $this->order_id);
+        $stmt->bindValue(':order_id', $this->order_id, PDO::PARAM_INT);
+        if ($cursor !== null) {
+            $stmt->bindValue(':cursor', $cursor, PDO::PARAM_INT);
+        }
+        $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
         $stmt->execute();
         return $stmt;
     }

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -18,21 +18,37 @@ class User {
         $this->conn = $db;
     }
 
-    public function readAll() {
+    public function readAll(int $limit = 30, ?int $cursor = null) {
         $query = "SELECT id, name, email, role FROM " . $this->table_name;
+        if ($cursor !== null) {
+            $query .= " WHERE id < :cursor";
+        }
+        $query .= " ORDER BY id DESC LIMIT :limit";
         $stmt = $this->conn->prepare($query);
+        if ($cursor !== null) {
+            $stmt->bindValue(':cursor', $cursor, PDO::PARAM_INT);
+        }
+        $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
         $stmt->execute();
         return $stmt;
     }
 
-    public function readAssistants(bool $includeBalance = false)
+    public function readAssistants(bool $includeBalance = false, int $limit = 30, ?int $cursor = null)
     {
         if ($includeBalance) {
             $query = "SELECT u.id, u.name, COALESCE(w.balance, 0) AS balance FROM {$this->table_name} u LEFT JOIN wallets w ON u.id = w.user_id WHERE u.role = 'assistant'";
         } else {
             $query = "SELECT id, name FROM {$this->table_name} WHERE role = 'assistant'";
         }
+        if ($cursor !== null) {
+            $query .= " AND id < :cursor";
+        }
+        $query .= " ORDER BY id DESC LIMIT :limit";
         $stmt = $this->conn->prepare($query);
+        if ($cursor !== null) {
+            $stmt->bindValue(':cursor', $cursor, PDO::PARAM_INT);
+        }
+        $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
         $stmt->execute();
         return $stmt;
     }

--- a/src/Models/Wallet.php
+++ b/src/Models/Wallet.php
@@ -24,10 +24,18 @@ class Wallet {
         return $stmt;
     }
 
-    public function readTransactions($user_id) {
-        $query = "SELECT id, user_id, amount, type, created_at FROM transactions WHERE user_id = ? ORDER BY created_at DESC";
+    public function readTransactions($user_id, int $limit = 30, ?int $cursor = null) {
+        $query = "SELECT id, user_id, amount, type, created_at FROM transactions WHERE user_id = :user_id";
+        if ($cursor !== null) {
+            $query .= " AND id < :cursor";
+        }
+        $query .= " ORDER BY id DESC LIMIT :limit";
         $stmt = $this->conn->prepare($query);
-        $stmt->bindParam(1, $user_id);
+        $stmt->bindValue(':user_id', $user_id, PDO::PARAM_INT);
+        if ($cursor !== null) {
+            $stmt->bindValue(':cursor', $cursor, PDO::PARAM_INT);
+        }
+        $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
         $stmt->execute();
         return $stmt;
     }


### PR DESCRIPTION
## Summary
- limit paginated list endpoints with a max size of 30
- support cursor-based navigation using last seen primary key
- document new pagination parameters and usage

## Testing
- `php -l src/Core/Pagination.php src/Controllers/AssistantController.php src/Controllers/HistoryLogController.php src/Controllers/OrderController.php src/Controllers/OrderItemController.php src/Controllers/PaymentController.php src/Controllers/UserController.php src/Controllers/WalletController.php src/Models/HistoryLog.php src/Models/Order.php src/Models/OrderItem.php src/Models/Payment.php src/Models/User.php src/Models/Wallet.php`

------
https://chatgpt.com/codex/tasks/task_b_68a6de8b1bc8832a81fb4996e422a1e7