### PR TITLE
feat: allow owners to create users

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Sample credentials you can use for testing:
 
 Use these when calling `POST /api/auth/login`.
 
-Additional owners or assistants should be created directly in the database.
-The API exposes no endpoints to register or modify users.
+Owners can create additional owners or assistants through the API using
+`POST /api/users`. User updates or deletions are not currently supported.
 
 ## Running
 
@@ -87,7 +87,12 @@ Endpoints annotated with **(🔒 requires token)** need this header.
 - `POST /api/auth/logout` – invalidate the current token. **(🔒 requires token)**
 - `GET /api/auth/me` – return information about the current user. **(🔒 requires token)**
 - `POST /api/auth/refresh` – issue a new token. **(🔒 requires token)**
-- *No registration endpoint is provided.*
+- User registration is limited to owners via `POST /api/users`.
+
+### Users
+- `GET /api/users` – list users. **(🔒 requires token)**
+- `GET /api/users/{id}` – retrieve a specific user. **(🔒 requires token)**
+- `POST /api/users` – create an owner or assistant (owners only). **(🔒 requires token)**
 
 ### Orders
 - `GET /api/orders` – list orders. Supports `status` and `assigned_to` query parameters (`assigned_to=null` for unassigned). **(🔒 requires token)**

--- a/docs.md
+++ b/docs.md
@@ -111,7 +111,28 @@ Requires an `Authorization: Bearer <token>` header.
 **Response**
 ```json
 {
-  "token": "<string>"
+"token": "<string>"
+}
+```
+
+## Users
+
+### `POST /api/users`
+Create a new owner or assistant. Only authenticated owners may call this endpoint.
+
+**Body parameters**
+- `name` – user name
+- `email` – user email
+- `password` – plain text password
+- `role` – `owner` or `assistant`
+
+**Response**
+```json
+{
+  "id": 4,
+  "name": "New Assistant",
+  "email": "assistant@example.com",
+  "role": "assistant"
 }
 ```
 

--- a/index.php
+++ b/index.php
@@ -17,6 +17,7 @@ use App\Controllers\PaymentController;
 use App\Controllers\WalletController;
 use App\Controllers\AnalyticsController;
 use App\Controllers\AssistantController;
+use App\Controllers\UserController;
 use App\Core\ResponseHelper;
 
 $allowedOrigin = $_ENV['ALLOWED_ORIGIN'];
@@ -154,6 +155,12 @@ switch ($resource) {
             } else {
                 ResponseHelper::error(404, 'Endpoint not found.');
             }
+            break;
+        }
+        // /api/users
+        if ($second === 'users') {
+            $userController = new UserController();
+            $userController->processRequest($method, $third);
             break;
         }
         // /api/assistants

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -12,6 +12,7 @@ class User {
     public $id;
     public $name;
     public $email;
+    public $password;
     public $role;
 
     public function __construct(PDO $db) {
@@ -62,13 +63,15 @@ class User {
     }
 
     public function create() {
-        $query = "INSERT INTO " . $this->table_name . " SET name = :name, email = :email, role = :role";
+        $query = "INSERT INTO " . $this->table_name . " SET name = :name, email = :email, password = :password, role = :role";
         $stmt = $this->conn->prepare($query);
         $this->name = htmlspecialchars(strip_tags($this->name));
         $this->email = htmlspecialchars(strip_tags($this->email));
+        $this->password = htmlspecialchars(strip_tags($this->password));
         $this->role = htmlspecialchars(strip_tags($this->role));
         $stmt->bindParam(':name', $this->name);
         $stmt->bindParam(':email', $this->email);
+        $stmt->bindParam(':password', $this->password);
         $stmt->bindParam(':role', $this->role);
         if ($stmt->execute()) {
             $this->id = $this->conn->lastInsertId();


### PR DESCRIPTION
## Summary
- add user creation endpoint and route for owners
- persist passwords and roles when creating users
- document the new `/api/users` endpoints

## Testing
- `php -l index.php`
- `php -l src/Controllers/UserController.php`
- `php -l src/Models/User.php`


------
https://chatgpt.com/codex/tasks/task_b_68aae5df9804832a9fd1f310b5b94a0c