### PR TITLE
Fix routing with query params

### DIFF
--- a/index.php
+++ b/index.php
@@ -32,7 +32,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 }
 
 $method = $_SERVER['REQUEST_METHOD'];
-$path = isset($_SERVER['REQUEST_URI']) ? trim($_SERVER['REQUEST_URI'], '/') : '';
+$requestUri = $_SERVER['REQUEST_URI'] ?? '';
+// Remove any query string from the request URI before splitting into segments
+$path = trim(parse_url($requestUri, PHP_URL_PATH), '/');
 $segments = explode('/', $path);
 
 $resource = $segments[0] ?? null;


### PR DESCRIPTION
## Summary
- ensure query strings don't affect path parsing

## Testing
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_b_68abeb397238832a9a256f981d26c795