### PR TITLE
Check for existing email before user creation

### DIFF
--- a/src/Controllers/UserController.php
+++ b/src/Controllers/UserController.php
@@ -102,6 +102,12 @@ class UserController {
 
         $this->user->name = $data['name'];
         $this->user->email = $data['email'];
+
+        if ($this->user->emailExists()) {
+            ResponseHelper::error(409, 'Email already exists.');
+            return;
+        }
+
         $this->user->password = password_hash($data['password'], PASSWORD_DEFAULT);
         $this->user->role = $role;
         if ($this->user->create()) {

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -62,6 +62,14 @@ class User {
         return $stmt;
     }
 
+    public function emailExists() {
+        $query = "SELECT id FROM " . $this->table_name . " WHERE email = ? LIMIT 1";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(1, $this->email);
+        $stmt->execute();
+        return $stmt->rowCount() > 0;
+    }
+
     public function create() {
         $query = "INSERT INTO " . $this->table_name . " SET name = :name, email = :email, password = :password, role = :role";
         $stmt = $this->conn->prepare($query);


### PR DESCRIPTION
## Summary
- ensure `UserController` validates email uniqueness prior to creating a user and returns a 409 error when a duplicate is found
- add `emailExists` helper to the `User` model for duplicate email detection

## Testing
- `php -l src/Models/User.php`
- `php -l src/Controllers/UserController.php`


------
https://chatgpt.com/codex/tasks/task_b_68ae981de4c0832a83e7f1cefd01c14d