### PR TITLE
Ensure new assistants receive wallets

### DIFF
--- a/src/Controllers/UserController.php
+++ b/src/Controllers/UserController.php
@@ -5,6 +5,7 @@ namespace App\Controllers;
 
 use App\Core\Database;
 use App\Models\User;
+use App\Models\Wallet;
 use App\Core\ResponseHelper;
 use App\Core\Validator;
 use PDO;
@@ -111,6 +112,10 @@ class UserController {
         $this->user->password = password_hash($data['password'], PASSWORD_DEFAULT);
         $this->user->role = $role;
         if ($this->user->create()) {
+            if ($role === 'assistant') {
+                $wallet = new Wallet($this->db);
+                $wallet->create($this->user->id);
+            }
             ResponseHelper::success('User created successfully', [
                 'id' => $this->user->id,
                 'name' => $this->user->name,

--- a/src/Models/Wallet.php
+++ b/src/Models/Wallet.php
@@ -16,6 +16,14 @@ class Wallet {
         $this->conn = $db;
     }
 
+    public function create(int $userId): bool
+    {
+        $query = "INSERT INTO {$this->table_name} (user_id, balance) VALUES (:user_id, 0)";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(':user_id', $userId);
+        return $stmt->execute();
+    }
+
     public function getBalance($user_id) {
         $query = "SELECT balance FROM " . $this->table_name . " WHERE user_id = ? LIMIT 1";
         $stmt = $this->conn->prepare($query);


### PR DESCRIPTION
## Summary
- create wallet records for newly created assistants
- add Wallet::create helper

## Testing
- `php -l src/Models/Wallet.php`
- `php -l src/Controllers/UserController.php`


------
https://chatgpt.com/codex/tasks/task_b_68aece54e198832a82182d8746304fb6