### PR TITLE
Add password update endpoint

### DIFF
--- a/index.php
+++ b/index.php
@@ -76,6 +76,13 @@ switch ($resource) {
                         ResponseHelper::error(405, 'Method not allowed.');
                     }
                     break;
+                case 'password':
+                    if ($method === 'PUT') {
+                        $auth->updatePassword();
+                    } else {
+                        ResponseHelper::error(405, 'Method not allowed.');
+                    }
+                    break;
                 default:
                     ResponseHelper::error(404, 'Endpoint not found.');
                     break;


### PR DESCRIPTION
## Summary
- Add updatePassword method in AuthController to allow logged-in users to change their password after verifying the current one
- Register new PUT /api/auth/password route
- Rely on AuthMiddleware user context instead of manual token parsing for password updates

## Testing
- `php -l src/Controllers/AuthController.php`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_b_68b26c0a6530832aa4c6fe53d943e220