### PR TITLE
Add assistant dashboard analytics endpoint

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -14,6 +14,7 @@ The API supports an owner–assistant purchasing workflow. The list below shows 
 ### Assistant dashboard
 - **Assigned orders** – `GET /api/orders` with client-side filtering by `assigned_to`, `owner_id`, or `status`.
 - **Wallet balance** – `GET /api/wallet/{assistant_id}`.
+- **Dashboard stats** – `GET /api/analytics/assistant`.
 
 ### Purchase entry / order detail
 - **Update item status and costs** – `PUT /api/order_items/{order_id}/{item_id}`.
@@ -36,6 +37,7 @@ The API supports an owner–assistant purchasing workflow. The list below shows 
 
 ### Dashboards & Analytics
 - **Owner Dashboard stats** – Overall counts and expense figures come from GET /api/analytics/dashboard; monthly breakdowns are available via GET /api/analytics/reports
+- **Assistant Dashboard stats** – Assistants can view their totals with GET /api/analytics/assistant
 
 ### Example flow
 1. Owner creates an order – `POST /api/orders`.

--- a/index.php
+++ b/index.php
@@ -159,6 +159,8 @@ switch ($resource) {
                 $analyticsController->dashboard();
             } elseif ($third === 'reports' && $method === 'GET') {
                 $analyticsController->reports();
+            } elseif ($third === 'assistant' && $method === 'GET') {
+                $analyticsController->assistantDashboard();
             } elseif ($third === 'assistants' && $fourth && $method === 'GET') {
                 $analyticsController->assistantSummary($fourth);
             } else {


### PR DESCRIPTION
## Summary
- Allow assistants to view dashboard analytics via new `GET /api/analytics/assistant` endpoint
- Route to assistant dashboard and related controller method
- Document assistant analytics endpoint in API docs
- Compute assistant expense totals from wallet transactions

## Testing
- `php -l src/Controllers/AnalyticsController.php`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_b_68b546f10230832ab5ab61f9ef1fd688