### PR TITLE
Add endpoint to list owners

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -739,4 +739,25 @@ List assistant users.
 
 ---
 
+## Owners
+
+### `GET /api/owners`
+List owner users.
+
+**Query parameters**
+- `limit` – number of records to return (max 30).
+- `cursor` – return records with IDs less than this value.
+
+**Response**
+```json
+[
+  {
+    "id": 1,
+    "name": "Owner Jane"
+  }
+]
+```
+
+---
+
 All timestamps follow the `YYYY-MM-DD HH:MM:SS` format and are generated using the `Asia/Dhaka` timezone. Endpoints may return standard HTTP error codes for validation or authorization failures. Error bodies follow the structure shown above.

--- a/index.php
+++ b/index.php
@@ -17,6 +17,7 @@ use App\Controllers\PaymentController;
 use App\Controllers\WalletController;
 use App\Controllers\AnalyticsController;
 use App\Controllers\AssistantController;
+use App\Controllers\OwnerController;
 use App\Controllers\UserController;
 use App\Core\ResponseHelper;
 
@@ -178,6 +179,12 @@ switch ($resource) {
         if ($second === 'assistants') {
             $assistantController = new AssistantController();
             $assistantController->processRequest($method);
+            break;
+        }
+        // /api/owners
+        if ($second === 'owners') {
+            $ownerController = new OwnerController();
+            $ownerController->processRequest($method);
             break;
         }
         // Fallback

--- a/src/Controllers/OwnerController.php
+++ b/src/Controllers/OwnerController.php
@@ -1,0 +1,48 @@
+<?php
+// File: src/Controllers/OwnerController.php
+
+namespace App\Controllers;
+
+use App\Core\Database;
+use App\Models\User;
+use App\Core\ResponseHelper;
+use PDO;
+use App\Core\AuthMiddleware;
+
+class OwnerController {
+    private $db;
+    private $user;
+
+    public function __construct() {
+        $database = new Database();
+        $this->db = $database->getConnection();
+        $this->user = new User($this->db);
+    }
+
+    public function processRequest($method) {
+        if (!AuthMiddleware::check()) {
+            return;
+        }
+        switch ($method) {
+            case 'GET':
+                $this->getOwners();
+                break;
+            default:
+                ResponseHelper::error(405, 'Method not allowed.');
+                break;
+        }
+    }
+
+    private function getOwners() {
+        [$limit, $cursor] = \App\Core\Pagination::getParams();
+        $stmt = $this->user->readOwners($limit, $cursor);
+        $owners = [];
+        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            $owners[] = [
+                'id' => $row['id'],
+                'name' => $row['name'],
+            ];
+        }
+        ResponseHelper::success('Owners retrieved successfully', $owners);
+    }
+}

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -54,6 +54,22 @@ class User {
         return $stmt;
     }
 
+    public function readOwners(int $limit = 30, ?int $cursor = null)
+    {
+        $query = "SELECT id, name FROM {$this->table_name} WHERE role = 'owner'";
+        if ($cursor !== null) {
+            $query .= " AND id < :cursor";
+        }
+        $query .= " ORDER BY id DESC LIMIT :limit";
+        $stmt = $this->conn->prepare($query);
+        if ($cursor !== null) {
+            $stmt->bindValue(':cursor', $cursor, PDO::PARAM_INT);
+        }
+        $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
+        $stmt->execute();
+        return $stmt;
+    }
+
     public function readOne() {
         $query = "SELECT id, name, email, role FROM " . $this->table_name . " WHERE id = ? LIMIT 1";
         $stmt = $this->conn->prepare($query);


### PR DESCRIPTION
## Summary
- allow querying owners via new readOwners method
- expose /api/owners endpoint through OwnerController and updated routing
- document new owners listing endpoint

## Testing
- `php -l src/Models/User.php`
- `php -l src/Controllers/OwnerController.php`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_b_68b6734da3c8832a9febec3f8f879c9d