### PR TITLE
Add filtering options to wallet transactions endpoint

### DIFF
--- a/src/Controllers/WalletController.php
+++ b/src/Controllers/WalletController.php
@@ -63,13 +63,34 @@ class WalletController {
             return;
         }
 
-
         if (!AuthMiddleware::check()) {
             return;
         }
 
+        $type = $_GET['type'] ?? null;
+        if ($type !== null && !in_array($type, ['credit', 'debit'], true)) {
+            ResponseHelper::error(400, 'Invalid type.');
+            return;
+        }
+
+        $fromRaw = $_GET['from'] ?? null;
+        $toRaw = $_GET['to'] ?? null;
+
+        if ($fromRaw !== null && !Validator::validateDate($fromRaw, 'Y-m-d')) {
+            ResponseHelper::error(400, 'Invalid from date.');
+            return;
+        }
+
+        if ($toRaw !== null && !Validator::validateDate($toRaw, 'Y-m-d')) {
+            ResponseHelper::error(400, 'Invalid to date.');
+            return;
+        }
+
+        $from = $fromRaw !== null ? $fromRaw . ' 00:00:00' : null;
+        $to = $toRaw !== null ? $toRaw . ' 23:59:59' : null;
+
         [$limit, $cursor] = \App\Core\Pagination::getParams();
-        $stmt = $this->wallet->readTransactions($user_id, $limit, $cursor);
+        $stmt = $this->wallet->readTransactions($user_id, $limit, $cursor, $type, $from, $to);
         $transactions_arr = [];
         while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
             $transactions_arr[] = [

--- a/src/Models/Wallet.php
+++ b/src/Models/Wallet.php
@@ -32,14 +32,39 @@ class Wallet {
         return $stmt;
     }
 
-    public function readTransactions($user_id, int $limit = 30, ?int $cursor = null) {
+    public function readTransactions(
+        $user_id,
+        int $limit = 30,
+        ?int $cursor = null,
+        ?string $type = null,
+        ?string $from = null,
+        ?string $to = null
+    ) {
         $query = "SELECT id, user_id, amount, type, created_at FROM transactions WHERE user_id = :user_id";
+        if ($type !== null) {
+            $query .= " AND type = :type";
+        }
+        if ($from !== null) {
+            $query .= " AND created_at >= :from";
+        }
+        if ($to !== null) {
+            $query .= " AND created_at <= :to";
+        }
         if ($cursor !== null) {
             $query .= " AND id < :cursor";
         }
         $query .= " ORDER BY id DESC LIMIT :limit";
         $stmt = $this->conn->prepare($query);
         $stmt->bindValue(':user_id', $user_id, PDO::PARAM_INT);
+        if ($type !== null) {
+            $stmt->bindValue(':type', $type);
+        }
+        if ($from !== null) {
+            $stmt->bindValue(':from', $from);
+        }
+        if ($to !== null) {
+            $stmt->bindValue(':to', $to);
+        }
         if ($cursor !== null) {
             $stmt->bindValue(':cursor', $cursor, PDO::PARAM_INT);
         }


### PR DESCRIPTION
## Summary
- allow filtering wallet transactions by type and date range
- support optional `type`, `from`, and `to` query params for `/api/wallet/{user_id}/transactions`

## Testing
- `php -l src/Controllers/WalletController.php`
- `php -l src/Models/Wallet.php`


------
https://chatgpt.com/codex/tasks/task_b_68b6bfab5310832aaca019ec6a7a2933