### PR TITLE
Include assistant and owner names in payment responses

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -456,7 +456,9 @@ List recorded payments.
   {
     "id": 1,
     "user_id": 2,
+    "assistant_name": "Jane Doe",
     "owner_id": 1,
+    "owner_name": "John Owner",
     "amount": 100.0,
     "type": "credit",
     "created_at": "2024-01-03 08:00:00"
@@ -472,7 +474,9 @@ Record a payment or expense.
 {
   "id": 2,
   "user_id": 2,
+  "assistant_name": "Jane Doe",
   "owner_id": 1,
+  "owner_name": "John Owner",
   "amount": 50.0,
   "type": "debit",
   "created_at": "2024-01-03 10:00:00"

--- a/src/Controllers/PaymentController.php
+++ b/src/Controllers/PaymentController.php
@@ -76,7 +76,9 @@ class PaymentController {
             $payments_arr[] = [
                 'id' => $row['id'],
                 'user_id' => $row['user_id'],
+                'assistant_name' => $row['assistant_name'],
                 'owner_id' => $row['owner_id'],
+                'owner_name' => $row['owner_name'],
                 'amount' => $row['amount'],
                 'type' => $row['type'],
                 'created_at' => $row['created_at'],
@@ -160,10 +162,19 @@ class PaymentController {
             $wallet->updateBalance($data['user_id'], $walletDelta);
             $wallet->addTransaction($data['user_id'], abs($data['amount']), $transactionType, TIMESTAMP);
             $this->logAction('payment', $this->payment->id, 'create', AuthMiddleware::$userId, $data);
+
+            $stmt = $this->db->prepare('SELECT name FROM users WHERE id = ? LIMIT 1');
+            $stmt->execute([$this->payment->user_id]);
+            $assistantName = $stmt->fetch(PDO::FETCH_COLUMN) ?: null;
+            $stmt->execute([$this->payment->owner_id]);
+            $ownerName = $stmt->fetch(PDO::FETCH_COLUMN) ?: null;
+
             ResponseHelper::success('Payment created successfully', [
                 'id' => $this->payment->id,
                 'user_id' => $this->payment->user_id,
+                'assistant_name' => $assistantName,
                 'owner_id' => $this->payment->owner_id,
+                'owner_name' => $ownerName,
                 'amount' => $this->payment->amount,
                 'type' => $this->payment->type,
                 'created_at' => $this->payment->created_at,

--- a/src/Models/Payment.php
+++ b/src/Models/Payment.php
@@ -21,37 +21,37 @@ class Payment {
     }
 
     public function readAll(array $filters = [], int $limit = 30, ?int $cursor = null) {
-        $query = "SELECT id, user_id, owner_id, amount, type, created_at FROM " . $this->table_name;
+        $query = "SELECT p.id, p.user_id, u.name AS assistant_name, p.owner_id, o.name AS owner_name, p.amount, p.type, p.created_at FROM " . $this->table_name . " p LEFT JOIN users u ON p.user_id = u.id LEFT JOIN users o ON p.owner_id = o.id";
         $conditions = [];
         $params = [];
         if (isset($filters['user_id'])) {
-            $conditions[] = "user_id = :user_id";
+            $conditions[] = "p.user_id = :user_id";
             $params[':user_id'] = $filters['user_id'];
         }
         if (isset($filters['owner_id'])) {
-            $conditions[] = "owner_id = :owner_id";
+            $conditions[] = "p.owner_id = :owner_id";
             $params[':owner_id'] = $filters['owner_id'];
         }
         if (isset($filters['type'])) {
-            $conditions[] = "type = :type";
+            $conditions[] = "p.type = :type";
             $params[':type'] = $filters['type'];
         }
         if (isset($filters['from'])) {
-            $conditions[] = "created_at >= :from";
+            $conditions[] = "p.created_at >= :from";
             $params[':from'] = $filters['from'];
         }
         if (isset($filters['to'])) {
-            $conditions[] = "created_at <= :to";
+            $conditions[] = "p.created_at <= :to";
             $params[':to'] = $filters['to'];
         }
         if ($cursor !== null) {
-            $conditions[] = "id < :cursor";
+            $conditions[] = "p.id < :cursor";
             $params[':cursor'] = $cursor;
         }
         if ($conditions) {
             $query .= " WHERE " . implode(" AND ", $conditions);
         }
-        $query .= " ORDER BY id DESC LIMIT :limit";
+        $query .= " ORDER BY p.id DESC LIMIT :limit";
         $stmt = $this->conn->prepare($query);
         foreach ($params as $key => $value) {
             $stmt->bindValue($key, $value);


### PR DESCRIPTION
## Summary
- Join users table when listing payments to fetch assistant and owner names
- Return assistant_name and owner_name in payment create and list responses
- Document payment responses including assistant_name

## Testing
- `php -l src/Models/Payment.php`
- `php -l src/Controllers/PaymentController.php`


------
https://chatgpt.com/codex/tasks/task_b_68b7dae8bad8832a8bbd77ac975da5f6