### PR TITLE
feat: support changed_by filter across history endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ Endpoints annotated with **(🔒 requires token)** need this header.
 
 ### History
 - `GET /api/history` – list history logs. Supports a `changed_by` filter. **(🔒 requires token)**
-- `GET /api/history/{entity}` – logs for all instances of a given entity type. **(🔒 requires token)**
-- `GET /api/history/{entity}/{id}` – logs for a specific entity instance. **(🔒 requires token)**
+- `GET /api/history/{entity}` – logs for all instances of a given entity type. Supports a `changed_by` filter. **(🔒 requires token)**
+- `GET /api/history/{entity}/{id}` – logs for a specific entity instance. Supports a `changed_by` filter. **(🔒 requires token)**
 - `POST /api/history` – create a log entry. **(🔒 requires token)**
 - `DELETE /api/history/{id}` – delete a log entry. **(🔒 requires token)**
 

--- a/docs.md
+++ b/docs.md
@@ -565,6 +565,7 @@ List all history log entries.
 List log entries for all records of a given entity type (e.g. `order`).
 
 **Query parameters**
+- `changed_by` – filter by the user id that performed the action.
 - `limit` – number of records to return (max 30).
 - `cursor` – return records with IDs less than this value.
 
@@ -586,6 +587,7 @@ List log entries for all records of a given entity type (e.g. `order`).
 List log entries related to a particular entity (e.g. `order`).
 
 **Query parameters**
+- `changed_by` – filter by the user id that performed the action.
 - `limit` – number of records to return (max 30).
 - `cursor` – return records with IDs less than this value.
 

--- a/src/Controllers/HistoryLogController.php
+++ b/src/Controllers/HistoryLogController.php
@@ -83,9 +83,18 @@ class HistoryLogController {
     }
 
     private function getLogsByEntityType($type) {
+        $changedBy = $_GET['changed_by'] ?? null;
+        if ($changedBy !== null) {
+            if (!Validator::validateInt($changedBy)) {
+                ResponseHelper::error(400, 'Invalid user ID.');
+                return;
+            }
+            $changedBy = (int)$changedBy;
+        }
+
         $this->log->entity_type = $type;
         [$limit, $cursor] = \App\Core\Pagination::getParams();
-        $stmt = $this->log->readByEntityType($limit, $cursor);
+        $stmt = $this->log->readByEntityType($limit, $cursor, $changedBy);
         $logs_arr = [];
         while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
             $logs_arr[] = [
@@ -103,10 +112,19 @@ class HistoryLogController {
     }
 
     private function getLogsByEntity($type, $entityId) {
+        $changedBy = $_GET['changed_by'] ?? null;
+        if ($changedBy !== null) {
+            if (!Validator::validateInt($changedBy)) {
+                ResponseHelper::error(400, 'Invalid user ID.');
+                return;
+            }
+            $changedBy = (int)$changedBy;
+        }
+
         $this->log->entity_type = $type;
         $this->log->entity_id = (int)$entityId;
         [$limit, $cursor] = \App\Core\Pagination::getParams();
-        $stmt = $this->log->readByEntity($limit, $cursor);
+        $stmt = $this->log->readByEntity($limit, $cursor, $changedBy);
         $logs_arr = [];
         while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
             $logs_arr[] = [

--- a/src/Models/HistoryLog.php
+++ b/src/Models/HistoryLog.php
@@ -54,14 +54,20 @@ class HistoryLog {
         return $stmt;
     }
 
-    public function readByEntityType(int $limit = 30, ?int $cursor = null) {
+    public function readByEntityType(int $limit = 30, ?int $cursor = null, ?int $userId = null) {
         $query = "SELECT h.id, h.entity_type, h.entity_id, h.action, h.changed_by_user_id, u.name AS changed_by_user_name, h.timestamp, h.data_snapshot FROM " . $this->table_name . " h LEFT JOIN users u ON h.changed_by_user_id = u.id WHERE h.entity_type = :entity_type";
+        if ($userId !== null) {
+            $query .= " AND h.changed_by_user_id = :user_id";
+        }
         if ($cursor !== null) {
             $query .= " AND h.id < :cursor";
         }
         $query .= " ORDER BY h.id DESC LIMIT :limit";
         $stmt = $this->conn->prepare($query);
         $stmt->bindParam(':entity_type', $this->entity_type, PDO::PARAM_STR);
+        if ($userId !== null) {
+            $stmt->bindParam(':user_id', $userId, PDO::PARAM_INT);
+        }
         if ($cursor !== null) {
             $stmt->bindValue(':cursor', $cursor, PDO::PARAM_INT);
         }
@@ -70,8 +76,11 @@ class HistoryLog {
         return $stmt;
     }
 
-    public function readByEntity(int $limit = 30, ?int $cursor = null) {
+    public function readByEntity(int $limit = 30, ?int $cursor = null, ?int $userId = null) {
         $query = "SELECT h.id, h.entity_type, h.entity_id, h.action, h.changed_by_user_id, u.name AS changed_by_user_name, h.timestamp, h.data_snapshot FROM " . $this->table_name . " h LEFT JOIN users u ON h.changed_by_user_id = u.id WHERE h.entity_type = :entity_type AND h.entity_id = :entity_id";
+        if ($userId !== null) {
+            $query .= " AND h.changed_by_user_id = :user_id";
+        }
         if ($cursor !== null) {
             $query .= " AND h.id < :cursor";
         }
@@ -79,6 +88,9 @@ class HistoryLog {
         $stmt = $this->conn->prepare($query);
         $stmt->bindParam(':entity_type', $this->entity_type, PDO::PARAM_STR);
         $stmt->bindParam(':entity_id', $this->entity_id, PDO::PARAM_INT);
+        if ($userId !== null) {
+            $stmt->bindParam(':user_id', $userId, PDO::PARAM_INT);
+        }
         if ($cursor !== null) {
             $stmt->bindValue(':cursor', $cursor, PDO::PARAM_INT);
         }


### PR DESCRIPTION
## Summary
- allow `changed_by` query on entity type and specific entity history routes
- update docs to mention the optional user filter

## Testing
- `php -l src/Controllers/HistoryLogController.php`
- `php -l src/Models/HistoryLog.php`


------
https://chatgpt.com/codex/tasks/task_b_68b7e675875c832a92e1523cb0f29a24