### PR TITLE
Ensure order creation logs include order ID

### DIFF
--- a/src/Controllers/OrderController.php
+++ b/src/Controllers/OrderController.php
@@ -225,7 +225,9 @@ class OrderController {
             }
 
             $this->db->commit();
-            $this->logAction('order', $this->order->id, 'create', AuthMiddleware::$userId, $data);
+            $logData = $data;
+            $logData['order_id'] = $this->order->id;
+            $this->logAction('order', $this->order->id, 'create', AuthMiddleware::$userId, $logData);
             ResponseHelper::success('Order created successfully', [
                 'id' => $this->order->id,
                 'created_by' => $this->order->created_by,


### PR DESCRIPTION
## Summary
- Include order ID in create order log snapshot using an explicit `order_id` key to avoid conflicts with item IDs

## Testing
- `php -l src/Controllers/OrderController.php`


------
https://chatgpt.com/codex/tasks/task_b_68b9358d3374832a9033f2cbfd511098