### PR TITLE
Ensure assigned orders start with assigned status

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -174,7 +174,8 @@ items can be submitted together with the order by providing an `items` array.
 **Body parameters**
 - `assigned_to` – user id of the assistant the order is assigned to (optional).
   If omitted, the order is left unassigned and an assistant may claim it later.
-- `status` – order status string (required)
+  When provided, the order status is automatically set to `assigned`.
+- `status` – order status string (required, ignored when `assigned_to` is set)
 - `items` – array of order item objects (optional). Each item accepts the same
   fields as `POST /api/order_items` except for `order_id`.
 

--- a/docs.md
+++ b/docs.md
@@ -175,7 +175,7 @@ items can be submitted together with the order by providing an `items` array.
 - `assigned_to` – user id of the assistant the order is assigned to (optional).
   If omitted, the order is left unassigned and an assistant may claim it later.
   When provided, the order status is automatically set to `assigned`.
-- `status` – order status string (required, ignored when `assigned_to` is set)
+- `status` – order status string (required; overridden to `assigned` if `assigned_to` is provided)
 - `items` – array of order item objects (optional). Each item accepts the same
   fields as `POST /api/order_items` except for `order_id`.
 

--- a/src/Controllers/OrderController.php
+++ b/src/Controllers/OrderController.php
@@ -174,6 +174,9 @@ class OrderController {
         $this->order->created_by = AuthMiddleware::$userId;
         $this->order->assigned_to = $data['assigned_to'] ?? null;
         $this->order->status = $data['status'];
+        if ($this->order->assigned_to !== null) {
+            $this->order->status = 'assigned';
+        }
         $this->order->created_at = TIMESTAMP;
         $this->order->completed_at = null;
 


### PR DESCRIPTION
## Summary
- Set order status to `assigned` during creation when an assignee is provided
- Document that providing `assigned_to` overrides the status field

## Testing
- `php -l src/Controllers/OrderController.php`

------
https://chatgpt.com/codex/tasks/task_b_68b958bd9dcc832a8c2c685ca677da2d